### PR TITLE
feat(recipe): image IDs in all recipe responses

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -990,7 +990,7 @@ const docTemplate = `{
         },
         "/recipe": {
             "post": {
-                "description": "Create a new recipe with ingredients, tags (by IDs or names), categories, and steps. The \"tag_id\" field is used to list already existing tags and \"tag_names\" is used to list new tags needs to be added to DB",
+                "description": "Create a new recipe with ingredients, tags (by IDs or names), categories, steps, and returns the new recipe including image IDs",
                 "consumes": [
                     "application/json"
                 ],
@@ -1016,7 +1016,7 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/controller.RecipeResponse"
+                            "$ref": "#/definitions/controller.RecipeWithImageIDs"
                         }
                     },
                     "400": {
@@ -1036,7 +1036,7 @@ const docTemplate = `{
         },
         "/recipe/list": {
             "get": {
-                "description": "Retrieve recipes with pagination, includes comments and ingredients",
+                "description": "Retrieve recipes with pagination, including tags, categories, steps, and image IDs",
                 "tags": [
                     "recipes"
                 ],
@@ -1059,7 +1059,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/controller.RecipeListResponse"
+                            "$ref": "#/definitions/controller.RecipeListWithImagesResponse"
                         }
                     },
                     "400": {
@@ -1079,7 +1079,7 @@ const docTemplate = `{
         },
         "/recipe/{id}": {
             "get": {
-                "description": "Get detailed recipe info including ingredients, comments, tags, categories, and steps",
+                "description": "Get detailed recipe info including ingredients, comments, tags, categories, steps, and image IDs",
                 "tags": [
                     "recipes"
                 ],
@@ -1097,7 +1097,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/controller.RecipeResponse"
+                            "$ref": "#/definitions/controller.RecipeWithImageIDs"
                         }
                     },
                     "400": {
@@ -1852,10 +1852,7 @@ const docTemplate = `{
         },
         "/recipes/search": {
             "get": {
-                "description": "Retrieves a list of recipes matching the given filters.",
-                "produces": [
-                    "application/json"
-                ],
+                "description": "Retrieve a list of recipes matching the given filters, including tags, categories, steps, and image IDs",
                 "tags": [
                     "recipes"
                 ],
@@ -1914,10 +1911,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/controller.RecipeResponse"
-                            }
+                            "$ref": "#/definitions/controller.RecipeListWithImagesResponse"
                         }
                     },
                     "400": {
@@ -2913,13 +2907,13 @@ const docTemplate = `{
                 }
             }
         },
-        "controller.RecipeListResponse": {
+        "controller.RecipeListWithImagesResponse": {
             "type": "object",
             "properties": {
                 "data": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/model.Recipe"
+                        "$ref": "#/definitions/controller.RecipeWithImageIDs"
                     }
                 },
                 "message": {
@@ -2927,14 +2921,50 @@ const docTemplate = `{
                 }
             }
         },
-        "controller.RecipeResponse": {
+        "controller.RecipeWithImageIDs": {
             "type": "object",
             "properties": {
-                "data": {
-                    "$ref": "#/definitions/model.Recipe"
+                "categories": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.Category"
+                    }
                 },
-                "message": {
+                "created_at": {
                     "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "images": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "steps": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.Step"
+                    }
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.Tag"
+                    }
+                },
+                "text": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "user_id": {
+                    "type": "integer"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -979,7 +979,7 @@
         },
         "/recipe": {
             "post": {
-                "description": "Create a new recipe with ingredients, tags (by IDs or names), categories, and steps. The \"tag_id\" field is used to list already existing tags and \"tag_names\" is used to list new tags needs to be added to DB",
+                "description": "Create a new recipe with ingredients, tags (by IDs or names), categories, steps, and returns the new recipe including image IDs",
                 "consumes": [
                     "application/json"
                 ],
@@ -1005,7 +1005,7 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/controller.RecipeResponse"
+                            "$ref": "#/definitions/controller.RecipeWithImageIDs"
                         }
                     },
                     "400": {
@@ -1025,7 +1025,7 @@
         },
         "/recipe/list": {
             "get": {
-                "description": "Retrieve recipes with pagination, includes comments and ingredients",
+                "description": "Retrieve recipes with pagination, including tags, categories, steps, and image IDs",
                 "tags": [
                     "recipes"
                 ],
@@ -1048,7 +1048,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/controller.RecipeListResponse"
+                            "$ref": "#/definitions/controller.RecipeListWithImagesResponse"
                         }
                     },
                     "400": {
@@ -1068,7 +1068,7 @@
         },
         "/recipe/{id}": {
             "get": {
-                "description": "Get detailed recipe info including ingredients, comments, tags, categories, and steps",
+                "description": "Get detailed recipe info including ingredients, comments, tags, categories, steps, and image IDs",
                 "tags": [
                     "recipes"
                 ],
@@ -1086,7 +1086,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/controller.RecipeResponse"
+                            "$ref": "#/definitions/controller.RecipeWithImageIDs"
                         }
                     },
                     "400": {
@@ -1841,10 +1841,7 @@
         },
         "/recipes/search": {
             "get": {
-                "description": "Retrieves a list of recipes matching the given filters.",
-                "produces": [
-                    "application/json"
-                ],
+                "description": "Retrieve a list of recipes matching the given filters, including tags, categories, steps, and image IDs",
                 "tags": [
                     "recipes"
                 ],
@@ -1903,10 +1900,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/controller.RecipeResponse"
-                            }
+                            "$ref": "#/definitions/controller.RecipeListWithImagesResponse"
                         }
                     },
                     "400": {
@@ -2902,13 +2896,13 @@
                 }
             }
         },
-        "controller.RecipeListResponse": {
+        "controller.RecipeListWithImagesResponse": {
             "type": "object",
             "properties": {
                 "data": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/model.Recipe"
+                        "$ref": "#/definitions/controller.RecipeWithImageIDs"
                     }
                 },
                 "message": {
@@ -2916,14 +2910,50 @@
                 }
             }
         },
-        "controller.RecipeResponse": {
+        "controller.RecipeWithImageIDs": {
             "type": "object",
             "properties": {
-                "data": {
-                    "$ref": "#/definitions/model.Recipe"
+                "categories": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.Category"
+                    }
                 },
-                "message": {
+                "created_at": {
                     "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "images": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "steps": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.Step"
+                    }
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.Tag"
+                    }
+                },
+                "text": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "user_id": {
+                    "type": "integer"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -166,21 +166,45 @@ definitions:
       message:
         type: string
     type: object
-  controller.RecipeListResponse:
+  controller.RecipeListWithImagesResponse:
     properties:
       data:
         items:
-          $ref: '#/definitions/model.Recipe'
+          $ref: '#/definitions/controller.RecipeWithImageIDs'
         type: array
       message:
         type: string
     type: object
-  controller.RecipeResponse:
+  controller.RecipeWithImageIDs:
     properties:
-      data:
-        $ref: '#/definitions/model.Recipe'
-      message:
+      categories:
+        items:
+          $ref: '#/definitions/model.Category'
+        type: array
+      created_at:
         type: string
+      id:
+        type: integer
+      images:
+        items:
+          type: integer
+        type: array
+      steps:
+        items:
+          $ref: '#/definitions/model.Step'
+        type: array
+      tags:
+        items:
+          $ref: '#/definitions/model.Tag'
+        type: array
+      text:
+        type: string
+      title:
+        type: string
+      updated_at:
+        type: string
+      user_id:
+        type: integer
     type: object
   controller.ResetPasswordRequest:
     properties:
@@ -1115,8 +1139,7 @@ paths:
       consumes:
       - application/json
       description: Create a new recipe with ingredients, tags (by IDs or names), categories,
-        and steps. The "tag_id" field is used to list already existing tags and "tag_names"
-        is used to list new tags needs to be added to DB
+        steps, and returns the new recipe including image IDs
       parameters:
       - description: Recipe data
         in: body
@@ -1130,7 +1153,7 @@ paths:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/controller.RecipeResponse'
+            $ref: '#/definitions/controller.RecipeWithImageIDs'
         "400":
           description: Bad Request
           schema:
@@ -1173,7 +1196,7 @@ paths:
       - recipes
     get:
       description: Get detailed recipe info including ingredients, comments, tags,
-        categories, and steps
+        categories, steps, and image IDs
       parameters:
       - description: Recipe ID
         in: path
@@ -1184,7 +1207,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/controller.RecipeResponse'
+            $ref: '#/definitions/controller.RecipeWithImageIDs'
         "400":
           description: Bad Request
           schema:
@@ -1632,7 +1655,8 @@ paths:
       - recipes
   /recipe/list:
     get:
-      description: Retrieve recipes with pagination, includes comments and ingredients
+      description: Retrieve recipes with pagination, including tags, categories, steps,
+        and image IDs
       parameters:
       - description: Limit number of recipes
         in: query
@@ -1646,7 +1670,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/controller.RecipeListResponse'
+            $ref: '#/definitions/controller.RecipeListWithImagesResponse'
         "400":
           description: Bad Request
           schema:
@@ -1688,7 +1712,8 @@ paths:
       - recipes
   /recipes/search:
     get:
-      description: Retrieves a list of recipes matching the given filters.
+      description: Retrieve a list of recipes matching the given filters, including
+        tags, categories, steps, and image IDs
       parameters:
       - description: Filter by recipe title (partial match)
         in: query
@@ -1722,15 +1747,11 @@ paths:
         in: query
         name: offset
         type: integer
-      produces:
-      - application/json
       responses:
         "200":
           description: OK
           schema:
-            items:
-              $ref: '#/definitions/controller.RecipeResponse'
-            type: array
+            $ref: '#/definitions/controller.RecipeListWithImagesResponse'
         "400":
           description: Bad Request
           schema:

--- a/service/image-service.go
+++ b/service/image-service.go
@@ -162,15 +162,23 @@ func DeleteImage(entityType string, entityID, imageID uint, backend internal.Sto
 	return nil
 }
 
-func GetImagesForEntity(entityType string, entityID uint) ([]model.Image, error) {
+func GetImageIDsForEntity(entityType string, entityID uint) ([]uint, error) {
 	db, err := internal.GetGormInstance()
 	if err != nil {
 		return nil, fmt.Errorf("database connection error: %w", err)
 	}
 
 	var images []model.Image
-	err = db.Where("entity_type = ? AND entity_id = ?", entityType, entityID).Find(&images).Error
-	return images, err
+	if err := db.Where("entity_type = ? AND entity_id = ?", entityType, entityID).Find(&images).Error; err != nil {
+		return nil, err
+	}
+
+	ids := make([]uint, len(images))
+	for i, img := range images {
+		ids[i] = img.ID
+	}
+
+	return ids, nil
 }
 
 func DeleteImagesForEntity(entityType string, entityID uint, backend internal.StorageBackend) error {


### PR DESCRIPTION
- Modified all recipe handlers (GetRecipeHandler, GetAllRecipesHandler, SearchRecipesHandler, PostRecipeHandler) to include IDs of related images in API responses.
- Updated service layer: GetImageIDsForEntity() now returns []uint of image IDs instead of full Image structs.
- Added new response structs: RecipeWithImageIDs and RecipeListWithImagesResponse to standardize responses including image IDs.
- Updated Swagger annotations for all recipe endpoints to reflect new responses and document images field.
- Ensured pagination and search endpoints return image IDs for all recipes.
- Preserved original model structures; no changes were made to model package.
- This enhances frontend integration by providing image references alongside recipe data.