### PR TITLE
feat(recipe): favorite count + user favorite stat

### DIFF
--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -47,3 +47,22 @@ func AuthenticatJWT() gin.HandlerFunc {
 		c.Next()
 	}
 }
+
+func ExtractUserFromToken() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		authHeader := c.GetHeader("Authorization")
+		if authHeader != "" {
+			parts := strings.Split(authHeader, " ")
+			if len(parts) == 2 && parts[0] == "Bearer" {
+				tokenStr := parts[1]
+				claims, err := token.VerifyToken(tokenStr)
+				if err == nil {
+					if idFloat, ok := claims["sub"].(float64); ok {
+						c.Set("userID", uint(idFloat))
+					}
+				}
+			}
+		}
+		c.Next()
+	}
+}

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -12,7 +12,7 @@ func AddRoutes(r *gin.Engine) {
 	public := r.Group("/")
 	{
 		// Recipe read endpoints
-		public.GET("/recipe/:id", controller.GetRecipeHandler)
+		public.GET("/recipe/:id", middleware.ExtractUserFromToken(), controller.GetRecipeHandler)
 		public.GET("/recipe/list", controller.GetAllRecipesHandler)
 		public.GET("/recipe/:id/ingredients", controller.GetAllRecipeIngredientHandler)
 		public.GET("/recipe/:id/comments", controller.GetAllRecipeCommentsHandler)


### PR DESCRIPTION
- Added support for returning both the total number of users who have favorited a recipe and whether the currently authenticated user has favorited it.

- To enable detecting the logged-in user without restricting access to the recipe endpoint, introduced a new `AttachUserFromOptionalJWT` middleware. This middleware attempts to parse and verify a JWT from the Authorization header. If valid, it attaches the `userID` to the Gin context for downstream handlers to use; if missing or invalid, it silently skips authentication, preserving public access.