### PR TITLE
fix(api): Added PaginateAndCount

### DIFF
--- a/utils/paginatioin.go
+++ b/utils/paginatioin.go
@@ -1,0 +1,31 @@
+package utils
+
+import (
+	"errors"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+func PaginateAndCount[T any](c *gin.Context, query *gorm.DB, result *[]T) (int64, error) {
+	limit, offset, err := ValidateOffLimit(c.Query("limit"), c.Query("offset"))
+	if err != nil && !errors.Is(err, errors.New("invalid limit and offset values")) {
+		return 0, err
+	}
+	if limit == 0 {
+		limit = 10
+	}
+
+	var totalCount int64
+	if err := query.Count(&totalCount).Error; err != nil {
+		return 0, err
+	}
+
+	paginatedQuery := query.Limit(limit).Offset(offset)
+
+	if err := paginatedQuery.Find(result).Error; err != nil {
+		return 0, err
+	}
+
+	return totalCount, nil
+}


### PR DESCRIPTION
- Refactored pagination logic across all relevant handlers to use new `utils.PaginateAndCount` function, ensuring consistent inclusion of total count in responses. 
- Added `utils/pagination.go` with generic `PaginateAndCount` to handle limit/offset validation, counting, and fetching. 
- Updated handlers (`GetAllCategoriesHandler`, `GetAllTagsHandler`, `GetAllRecipesHandler`, `GetAllRecipeCommentsHandler`, `GetUserRecipesHandler`, `GetUserFavoritesHandler`, `GetUserRatingsHandler`, `SearchRecipesHandler`) to use this function, removing duplicated pagination code. 
- Modified `RecipeListWithImagesResponse` to include `Total` field for `SearchRecipesHandler`. 
- Improved DB efficiency by ensuring counts reflect filtered queries and maintained two-query approach (count + fetch). 
- Enhanced API consistency and maintainability.