### PR TITLE
feat(internal): Singleton Gorm instance

### DIFF
--- a/internal/gorm.go
+++ b/internal/gorm.go
@@ -1,12 +1,32 @@
 package internal
 
 import (
+	"log"
+	"sync"
+
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
 )
 
-func GetGormInstance() (db *gorm.DB, err error) {
-	dsn := "root:i1a3a7c7e@Se@tcp(127.0.0.1:3306)/recipes_db?charset=utf8mb4&parseTime=True&loc=Local"
-	db, err = gorm.Open(mysql.Open(dsn), &gorm.Config{})
-	return
+var (
+	db   *gorm.DB
+	once sync.Once
+)
+
+func GetGormInstance() (*gorm.DB, error) {
+	var err error
+	once.Do(func() {
+		dsn := "root:i1a3a7c7e@Se@tcp(127.0.0.1:3306)/recipes_db?charset=utf8mb4&parseTime=True&loc=Local"
+		db, err = gorm.Open(mysql.Open(dsn), &gorm.Config{})
+		if err != nil {
+			log.Println("failed to connect database:", err)
+			return
+		}
+
+		sqlDB, _ := db.DB()
+		sqlDB.SetMaxOpenConns(20)   // limit open connections
+		sqlDB.SetMaxIdleConns(10)   // keep some idle
+		sqlDB.SetConnMaxLifetime(0) // no forced recycling
+	})
+	return db, err
 }


### PR DESCRIPTION
-This change addresses the "too many connections" error that occurred when multiple requests triggered repeated database initializations.
- A singleton Gorm instance is now created using sync.Once, ensuring only one shared DB connection across the application.
- Additionally, connection pool limits (SetMaxOpenConns, SetMaxIdleConns, SetConnMaxLifetime) have been configured to prevent resource exhaustion and improve database stability under heavy load.