### PR TITLE
fix(api): Fix recipe update field handling

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1205,7 +1205,7 @@ const docTemplate = `{
                 }
             },
             "put": {
-                "description": "Updates the title, text, ingredients, and steps of a specific recipe",
+                "description": "Updates a recipe by ID. Replaces title, text, ingredients, steps, tags, and categories.",
                 "consumes": [
                     "application/json"
                 ],
@@ -1215,7 +1215,7 @@ const docTemplate = `{
                 "tags": [
                     "recipes"
                 ],
-                "summary": "Update a recipe",
+                "summary": "Update an existing recipe",
                 "parameters": [
                     {
                         "type": "integer",
@@ -1244,19 +1244,19 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/controller.ErrorResponse"
+                            "$ref": "#/definitions/controller.SimpleMessageResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/controller.ErrorResponse"
+                            "$ref": "#/definitions/controller.SimpleMessageResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/controller.ErrorResponse"
+                            "$ref": "#/definitions/controller.SimpleMessageResponse"
                         }
                     }
                 }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1194,7 +1194,7 @@
                 }
             },
             "put": {
-                "description": "Updates the title, text, ingredients, and steps of a specific recipe",
+                "description": "Updates a recipe by ID. Replaces title, text, ingredients, steps, tags, and categories.",
                 "consumes": [
                     "application/json"
                 ],
@@ -1204,7 +1204,7 @@
                 "tags": [
                     "recipes"
                 ],
-                "summary": "Update a recipe",
+                "summary": "Update an existing recipe",
                 "parameters": [
                     {
                         "type": "integer",
@@ -1233,19 +1233,19 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/controller.ErrorResponse"
+                            "$ref": "#/definitions/controller.SimpleMessageResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/controller.ErrorResponse"
+                            "$ref": "#/definitions/controller.SimpleMessageResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/controller.ErrorResponse"
+                            "$ref": "#/definitions/controller.SimpleMessageResponse"
                         }
                     }
                 }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1315,7 +1315,8 @@ paths:
     put:
       consumes:
       - application/json
-      description: Updates the title, text, ingredients, and steps of a specific recipe
+      description: Updates a recipe by ID. Replaces title, text, ingredients, steps,
+        tags, and categories.
       parameters:
       - description: Recipe ID
         in: path
@@ -1338,16 +1339,16 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/controller.ErrorResponse'
+            $ref: '#/definitions/controller.SimpleMessageResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/controller.ErrorResponse'
+            $ref: '#/definitions/controller.SimpleMessageResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/controller.ErrorResponse'
-      summary: Update a recipe
+            $ref: '#/definitions/controller.SimpleMessageResponse'
+      summary: Update an existing recipe
       tags:
       - recipes
   /recipe/{id}/calories:


### PR DESCRIPTION
- Only update associations (Ingredients, Steps, Tags, Categories) when explicitly provided in the request payload
- Preserve existing associations when fields are omitted, preventing accidental data deletion
- Fix Tag handling: create new tags by name if they don't exist, or associate existing ones
- Enforce Category integrity: reject requests referencing invalid category IDs instead of silently failing