### PR TITLE
fix(api): Unfavorite logic modified

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -528,53 +528,6 @@ const docTemplate = `{
                 }
             }
         },
-        "/favorite/{id}": {
-            "delete": {
-                "description": "Deletes a favorite record by its ID",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "favorites"
-                ],
-                "summary": "Delete a favorite by ID",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "Favorite ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/controller.SimpleMessageResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/controller.ErrorResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/controller.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/controller.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
         "/forgot-password": {
             "post": {
                 "description": "Sends password reset instructions if email exists",
@@ -2381,6 +2334,53 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/controller.TagsResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/unfavorite": {
+            "delete": {
+                "description": "Unfavorites a recipe for the authenticated user using its recipe ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "favorites"
+                ],
+                "summary": "Remove a recipe from favorites",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Recipe ID",
+                        "name": "recipeId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controller.SimpleMessageResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
                         }
                     },
                     "500": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -517,53 +517,6 @@
                 }
             }
         },
-        "/favorite/{id}": {
-            "delete": {
-                "description": "Deletes a favorite record by its ID",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "favorites"
-                ],
-                "summary": "Delete a favorite by ID",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "Favorite ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/controller.SimpleMessageResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/controller.ErrorResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/controller.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/controller.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
         "/forgot-password": {
             "post": {
                 "description": "Sends password reset instructions if email exists",
@@ -2370,6 +2323,53 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/controller.TagsResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/unfavorite": {
+            "delete": {
+                "description": "Unfavorites a recipe for the authenticated user using its recipe ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "favorites"
+                ],
+                "summary": "Remove a recipe from favorites",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Recipe ID",
+                        "name": "recipeId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controller.SimpleMessageResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
                         }
                     },
                     "500": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -890,37 +890,6 @@ paths:
       summary: Add a favorite recipe for the authenticated user
       tags:
       - favorites
-  /favorite/{id}:
-    delete:
-      description: Deletes a favorite record by its ID
-      parameters:
-      - description: Favorite ID
-        in: path
-        name: id
-        required: true
-        type: integer
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/controller.SimpleMessageResponse'
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/controller.ErrorResponse'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/controller.ErrorResponse'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/controller.ErrorResponse'
-      summary: Delete a favorite by ID
-      tags:
-      - favorites
   /forgot-password:
     post:
       consumes:
@@ -2132,6 +2101,38 @@ paths:
       summary: Get all tags
       tags:
       - tags
+  /unfavorite:
+    delete:
+      description: Unfavorites a recipe for the authenticated user using its recipe
+        ID
+      parameters:
+      - description: Recipe ID
+        in: path
+        name: recipeId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/controller.SimpleMessageResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/controller.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/controller.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/controller.ErrorResponse'
+      summary: Remove a recipe from favorites
+      tags:
+      - favorites
   /user/{id}/favorites:
     get:
       description: Retrieve a paginated list of favorite recipes for a specific user

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -70,7 +70,7 @@ func AddRoutes(r *gin.Engine) {
 
 		// Favorite management
 		protected.POST("/favorite", controller.PostFavoriteHandler)
-		protected.DELETE("/favorite/:id", controller.DeleteFavoriteHandler)
+		protected.DELETE("/unfavorite", controller.DeleteFavoriteHandler)
 
 		// Rating management
 		protected.POST("/rating", controller.PostRatingHandler)


### PR DESCRIPTION
- Modified DeleteFavoriteHandler to remove user id retrieval from request patameters and use the secure middleware to fetch user ID
- Changes related route from "/favorite/:id" to "/unfavorite", so recipe_id should be provided inside the query
- Reinitialized swagger docs to include recent changes