### PR TITLE
feat(admin): Add admin control functionality

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -103,6 +103,7 @@ func Signup(c *gin.Context) {
 		Email:    req.Email,
 		Password: hashedPassword,
 		Salt:     salt,
+		Role:     "user",
 	}
 
 	err = db.Create(&user).Error
@@ -162,7 +163,7 @@ func Login(c *gin.Context) {
 		return
 	}
 
-	tokenStr, err := token.GenerateToken(user.ID, user.Email)
+	tokenStr, err := token.GenerateToken(user.ID, user.Email, user.Role)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: messages.User.GeneratTokenFail.String()})
 		return

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -15,6 +15,272 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/admin/user/{userID}/comment/{id}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Admin deletes a comment of any user",
+                "tags": [
+                    "comments"
+                ],
+                "summary": "Delete a comment (admin)",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "User ID",
+                        "name": "userID",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Comment ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controller.SuccessMessageResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/user/{userID}/rating/{id}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Admin deletes a rating of any user",
+                "tags": [
+                    "ratings"
+                ],
+                "summary": "Delete a rating (admin)",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "User ID",
+                        "name": "userID",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Rating ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controller.SuccessMessageResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/user/{userID}/recipe/{id}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Admin deletes a recipe of any user",
+                "tags": [
+                    "recipes"
+                ],
+                "summary": "Delete a recipe (admin)",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "User ID",
+                        "name": "userID",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Recipe ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controller.SimpleMessageResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/user/{userID}/unfavorite/{favoriteID}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Admin removes a favorite of any user",
+                "tags": [
+                    "favorites"
+                ],
+                "summary": "Delete a favorite (admin)",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "User ID",
+                        "name": "userID",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Favorite ID",
+                        "name": "favoriteID",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controller.SuccessMessageResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/categories": {
             "get": {
                 "description": "Retrieve a paginated list of categories with total count, optionally sorted by name or creation date",
@@ -327,67 +593,6 @@ const docTemplate = `{
                 }
             }
         },
-        "/comment/{id}": {
-            "delete": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Delete a comment if it belongs to the authenticated user",
-                "tags": [
-                    "comments"
-                ],
-                "summary": "Delete a comment by ID",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "Comment ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/controller.SuccessMessageResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/controller.ErrorResponse"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/controller.ErrorResponse"
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/controller.ErrorResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/controller.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/controller.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
         "/comment/{id}/like/dec": {
             "post": {
                 "description": "Decrease likes for a comment by ID",
@@ -538,6 +743,70 @@ const docTemplate = `{
                     },
                     "500": {
                         "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/favorites": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retrieve a paginated list of all favorites with user and recipe details",
+                "tags": [
+                    "favorites"
+                ],
+                "summary": "Get all favorites",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "default": 10,
+                        "description": "Number of items per page",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 0,
+                        "description": "Pagination offset",
+                        "name": "offset",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "default": "date_desc",
+                        "description": "Sort order: date_asc, date_desc",
+                        "name": "sortOrder",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
                         "schema": {
                             "$ref": "#/definitions/controller.ErrorResponse"
                         }
@@ -959,32 +1228,49 @@ const docTemplate = `{
                         }
                     }
                 }
-            },
-            "delete": {
+            }
+        },
+        "/ratings": {
+            "get": {
                 "security": [
                     {
                         "BearerAuth": []
                     }
                 ],
-                "description": "Delete a rating if it belongs to the authenticated user",
+                "description": "Retrieve a paginated list of all ratings with user and recipe details",
                 "tags": [
                     "ratings"
                 ],
-                "summary": "Delete a rating by ID",
+                "summary": "Get all ratings",
                 "parameters": [
                     {
                         "type": "integer",
-                        "description": "Rating ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
+                        "default": 10,
+                        "description": "Number of items per page",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 0,
+                        "description": "Pagination offset",
+                        "name": "offset",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "default": "date_desc",
+                        "description": "Sort order: score_asc, score_desc, date_asc, date_desc",
+                        "name": "sortOrder",
+                        "in": "query"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/controller.SuccessMessageResponse"
+                            "type": "object",
+                            "additionalProperties": true
                         }
                     },
                     "400": {
@@ -995,18 +1281,6 @@ const docTemplate = `{
                     },
                     "401": {
                         "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/controller.ErrorResponse"
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/controller.ErrorResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
                         "schema": {
                             "$ref": "#/definitions/controller.ErrorResponse"
                         }
@@ -1244,65 +1518,6 @@ const docTemplate = `{
                         "description": "Internal Server Error",
                         "schema": {
                             "$ref": "#/definitions/controller.SimpleMessageResponse"
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Delete a recipe and all its associated entities if it belongs to the authenticated user",
-                "tags": [
-                    "recipes"
-                ],
-                "summary": "Delete a recipe by ID",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "Recipe ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/controller.SimpleMessageResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/controller.ErrorResponse"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/controller.ErrorResponse"
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/controller.ErrorResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/controller.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/controller.ErrorResponse"
                         }
                     }
                 }
@@ -2424,53 +2639,6 @@ const docTemplate = `{
                 }
             }
         },
-        "/unfavorite": {
-            "delete": {
-                "description": "Unfavorites a recipe for the authenticated user using its recipe ID",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "favorites"
-                ],
-                "summary": "Remove a recipe from favorites",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "Recipe ID",
-                        "name": "recipeId",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/controller.SimpleMessageResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/controller.ErrorResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/controller.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/controller.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
         "/user/favorites": {
             "get": {
                 "description": "Retrieve a paginated list of favorite recipes for the logged-in user",
@@ -2923,6 +3091,33 @@ const docTemplate = `{
                 }
             }
         },
+        "controller.FavoriteWithTitle": {
+            "type": "object",
+            "required": [
+                "recipe_id",
+                "user_id"
+            ],
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "recipe_id": {
+                    "type": "integer"
+                },
+                "recipe_title": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                },
+                "user_id": {
+                    "type": "integer"
+                }
+            }
+        },
         "controller.ForgotPasswordRequest": {
             "type": "object",
             "required": [
@@ -3321,7 +3516,7 @@ const docTemplate = `{
                 "data": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/model.Favorite"
+                        "$ref": "#/definitions/controller.FavoriteWithTitle"
                     }
                 },
                 "message": {
@@ -3826,6 +4021,9 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/model.Recipe"
                     }
+                },
+                "role": {
+                    "type": "string"
                 },
                 "salt": {
                     "type": "string"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -4,6 +4,272 @@
         "contact": {}
     },
     "paths": {
+        "/admin/user/{userID}/comment/{id}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Admin deletes a comment of any user",
+                "tags": [
+                    "comments"
+                ],
+                "summary": "Delete a comment (admin)",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "User ID",
+                        "name": "userID",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Comment ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controller.SuccessMessageResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/user/{userID}/rating/{id}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Admin deletes a rating of any user",
+                "tags": [
+                    "ratings"
+                ],
+                "summary": "Delete a rating (admin)",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "User ID",
+                        "name": "userID",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Rating ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controller.SuccessMessageResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/user/{userID}/recipe/{id}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Admin deletes a recipe of any user",
+                "tags": [
+                    "recipes"
+                ],
+                "summary": "Delete a recipe (admin)",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "User ID",
+                        "name": "userID",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Recipe ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controller.SimpleMessageResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/user/{userID}/unfavorite/{favoriteID}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Admin removes a favorite of any user",
+                "tags": [
+                    "favorites"
+                ],
+                "summary": "Delete a favorite (admin)",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "User ID",
+                        "name": "userID",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Favorite ID",
+                        "name": "favoriteID",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controller.SuccessMessageResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/categories": {
             "get": {
                 "description": "Retrieve a paginated list of categories with total count, optionally sorted by name or creation date",
@@ -316,67 +582,6 @@
                 }
             }
         },
-        "/comment/{id}": {
-            "delete": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Delete a comment if it belongs to the authenticated user",
-                "tags": [
-                    "comments"
-                ],
-                "summary": "Delete a comment by ID",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "Comment ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/controller.SuccessMessageResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/controller.ErrorResponse"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/controller.ErrorResponse"
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/controller.ErrorResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/controller.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/controller.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
         "/comment/{id}/like/dec": {
             "post": {
                 "description": "Decrease likes for a comment by ID",
@@ -527,6 +732,70 @@
                     },
                     "500": {
                         "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/favorites": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retrieve a paginated list of all favorites with user and recipe details",
+                "tags": [
+                    "favorites"
+                ],
+                "summary": "Get all favorites",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "default": 10,
+                        "description": "Number of items per page",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 0,
+                        "description": "Pagination offset",
+                        "name": "offset",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "default": "date_desc",
+                        "description": "Sort order: date_asc, date_desc",
+                        "name": "sortOrder",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/controller.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
                         "schema": {
                             "$ref": "#/definitions/controller.ErrorResponse"
                         }
@@ -948,32 +1217,49 @@
                         }
                     }
                 }
-            },
-            "delete": {
+            }
+        },
+        "/ratings": {
+            "get": {
                 "security": [
                     {
                         "BearerAuth": []
                     }
                 ],
-                "description": "Delete a rating if it belongs to the authenticated user",
+                "description": "Retrieve a paginated list of all ratings with user and recipe details",
                 "tags": [
                     "ratings"
                 ],
-                "summary": "Delete a rating by ID",
+                "summary": "Get all ratings",
                 "parameters": [
                     {
                         "type": "integer",
-                        "description": "Rating ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
+                        "default": 10,
+                        "description": "Number of items per page",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 0,
+                        "description": "Pagination offset",
+                        "name": "offset",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "default": "date_desc",
+                        "description": "Sort order: score_asc, score_desc, date_asc, date_desc",
+                        "name": "sortOrder",
+                        "in": "query"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/controller.SuccessMessageResponse"
+                            "type": "object",
+                            "additionalProperties": true
                         }
                     },
                     "400": {
@@ -984,18 +1270,6 @@
                     },
                     "401": {
                         "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/controller.ErrorResponse"
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/controller.ErrorResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
                         "schema": {
                             "$ref": "#/definitions/controller.ErrorResponse"
                         }
@@ -1233,65 +1507,6 @@
                         "description": "Internal Server Error",
                         "schema": {
                             "$ref": "#/definitions/controller.SimpleMessageResponse"
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Delete a recipe and all its associated entities if it belongs to the authenticated user",
-                "tags": [
-                    "recipes"
-                ],
-                "summary": "Delete a recipe by ID",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "Recipe ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/controller.SimpleMessageResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/controller.ErrorResponse"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/controller.ErrorResponse"
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/controller.ErrorResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/controller.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/controller.ErrorResponse"
                         }
                     }
                 }
@@ -2413,53 +2628,6 @@
                 }
             }
         },
-        "/unfavorite": {
-            "delete": {
-                "description": "Unfavorites a recipe for the authenticated user using its recipe ID",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "favorites"
-                ],
-                "summary": "Remove a recipe from favorites",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "Recipe ID",
-                        "name": "recipeId",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/controller.SimpleMessageResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/controller.ErrorResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/controller.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/controller.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
         "/user/favorites": {
             "get": {
                 "description": "Retrieve a paginated list of favorite recipes for the logged-in user",
@@ -2912,6 +3080,33 @@
                 }
             }
         },
+        "controller.FavoriteWithTitle": {
+            "type": "object",
+            "required": [
+                "recipe_id",
+                "user_id"
+            ],
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "recipe_id": {
+                    "type": "integer"
+                },
+                "recipe_title": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                },
+                "user_id": {
+                    "type": "integer"
+                }
+            }
+        },
         "controller.ForgotPasswordRequest": {
             "type": "object",
             "required": [
@@ -3310,7 +3505,7 @@
                 "data": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/model.Favorite"
+                        "$ref": "#/definitions/controller.FavoriteWithTitle"
                     }
                 },
                 "message": {
@@ -3815,6 +4010,9 @@
                     "items": {
                         "$ref": "#/definitions/model.Recipe"
                     }
+                },
+                "role": {
+                    "type": "string"
                 },
                 "salt": {
                     "type": "string"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -80,6 +80,24 @@ definitions:
       message:
         type: string
     type: object
+  controller.FavoriteWithTitle:
+    properties:
+      createdAt:
+        type: string
+      id:
+        type: integer
+      recipe_id:
+        type: integer
+      recipe_title:
+        type: string
+      updatedAt:
+        type: string
+      user_id:
+        type: integer
+    required:
+    - recipe_id
+    - user_id
+    type: object
   controller.ForgotPasswordRequest:
     properties:
       email:
@@ -346,7 +364,7 @@ definitions:
         type: integer
       data:
         items:
-          $ref: '#/definitions/model.Favorite'
+          $ref: '#/definitions/controller.FavoriteWithTitle'
         type: array
       message:
         type: string
@@ -687,6 +705,8 @@ definitions:
         items:
           $ref: '#/definitions/model.Recipe'
         type: array
+      role:
+        type: string
       salt:
         type: string
       updatedAt:
@@ -695,6 +715,178 @@ definitions:
 info:
   contact: {}
 paths:
+  /admin/user/{userID}/comment/{id}:
+    delete:
+      description: Admin deletes a comment of any user
+      parameters:
+      - description: User ID
+        in: path
+        name: userID
+        required: true
+        type: integer
+      - description: Comment ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/controller.SuccessMessageResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/controller.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/controller.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/controller.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/controller.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/controller.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Delete a comment (admin)
+      tags:
+      - comments
+  /admin/user/{userID}/rating/{id}:
+    delete:
+      description: Admin deletes a rating of any user
+      parameters:
+      - description: User ID
+        in: path
+        name: userID
+        required: true
+        type: integer
+      - description: Rating ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/controller.SuccessMessageResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/controller.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/controller.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/controller.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/controller.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/controller.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Delete a rating (admin)
+      tags:
+      - ratings
+  /admin/user/{userID}/recipe/{id}:
+    delete:
+      description: Admin deletes a recipe of any user
+      parameters:
+      - description: User ID
+        in: path
+        name: userID
+        required: true
+        type: integer
+      - description: Recipe ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/controller.SimpleMessageResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/controller.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/controller.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/controller.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/controller.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/controller.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Delete a recipe (admin)
+      tags:
+      - recipes
+  /admin/user/{userID}/unfavorite/{favoriteID}:
+    delete:
+      description: Admin removes a favorite of any user
+      parameters:
+      - description: User ID
+        in: path
+        name: userID
+        required: true
+        type: integer
+      - description: Favorite ID
+        in: path
+        name: favoriteID
+        required: true
+        type: integer
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/controller.SuccessMessageResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/controller.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/controller.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/controller.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/controller.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Delete a favorite (admin)
+      tags:
+      - favorites
   /categories:
     get:
       description: Retrieve a paginated list of categories with total count, optionally
@@ -902,45 +1094,6 @@ paths:
       summary: Post a new comment on a recipe
       tags:
       - comments
-  /comment/{id}:
-    delete:
-      description: Delete a comment if it belongs to the authenticated user
-      parameters:
-      - description: Comment ID
-        in: path
-        name: id
-        required: true
-        type: integer
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/controller.SuccessMessageResponse'
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/controller.ErrorResponse'
-        "401":
-          description: Unauthorized
-          schema:
-            $ref: '#/definitions/controller.ErrorResponse'
-        "403":
-          description: Forbidden
-          schema:
-            $ref: '#/definitions/controller.ErrorResponse'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/controller.ErrorResponse'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/controller.ErrorResponse'
-      security:
-      - BearerAuth: []
-      summary: Delete a comment by ID
-      tags:
-      - comments
   /comment/{id}/like/dec:
     post:
       description: Decrease likes for a comment by ID
@@ -1042,6 +1195,49 @@ paths:
       security:
       - BearerAuth: []
       summary: Add a favorite recipe for the authenticated user
+      tags:
+      - favorites
+  /favorites:
+    get:
+      description: Retrieve a paginated list of all favorites with user and recipe
+        details
+      parameters:
+      - default: 10
+        description: Number of items per page
+        in: query
+        name: limit
+        type: integer
+      - default: 0
+        description: Pagination offset
+        in: query
+        name: offset
+        type: integer
+      - default: date_desc
+        description: 'Sort order: date_asc, date_desc'
+        in: query
+        name: sortOrder
+        type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/controller.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/controller.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/controller.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Get all favorites
       tags:
       - favorites
   /forgot-password:
@@ -1280,44 +1476,6 @@ paths:
       tags:
       - ratings
   /rating/{id}:
-    delete:
-      description: Delete a rating if it belongs to the authenticated user
-      parameters:
-      - description: Rating ID
-        in: path
-        name: id
-        required: true
-        type: integer
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/controller.SuccessMessageResponse'
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/controller.ErrorResponse'
-        "401":
-          description: Unauthorized
-          schema:
-            $ref: '#/definitions/controller.ErrorResponse'
-        "403":
-          description: Forbidden
-          schema:
-            $ref: '#/definitions/controller.ErrorResponse'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/controller.ErrorResponse'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/controller.ErrorResponse'
-      security:
-      - BearerAuth: []
-      summary: Delete a rating by ID
-      tags:
-      - ratings
     put:
       consumes:
       - application/json
@@ -1356,6 +1514,48 @@ paths:
       summary: Update a rating by ID
       tags:
       - ratings
+  /ratings:
+    get:
+      description: Retrieve a paginated list of all ratings with user and recipe details
+      parameters:
+      - default: 10
+        description: Number of items per page
+        in: query
+        name: limit
+        type: integer
+      - default: 0
+        description: Pagination offset
+        in: query
+        name: offset
+        type: integer
+      - default: date_desc
+        description: 'Sort order: score_asc, score_desc, date_asc, date_desc'
+        in: query
+        name: sortOrder
+        type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/controller.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/controller.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/controller.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Get all ratings
+      tags:
+      - ratings
   /recipe:
     post:
       consumes:
@@ -1388,45 +1588,6 @@ paths:
       tags:
       - recipes
   /recipe/{id}:
-    delete:
-      description: Delete a recipe and all its associated entities if it belongs to
-        the authenticated user
-      parameters:
-      - description: Recipe ID
-        in: path
-        name: id
-        required: true
-        type: integer
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/controller.SimpleMessageResponse'
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/controller.ErrorResponse'
-        "401":
-          description: Unauthorized
-          schema:
-            $ref: '#/definitions/controller.ErrorResponse'
-        "403":
-          description: Forbidden
-          schema:
-            $ref: '#/definitions/controller.ErrorResponse'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/controller.ErrorResponse'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/controller.ErrorResponse'
-      security:
-      - BearerAuth: []
-      summary: Delete a recipe by ID
-      tags:
-      - recipes
     get:
       description: Get detailed recipe info including ingredients, comments, tags,
         categories, steps, and image IDs
@@ -2293,38 +2454,6 @@ paths:
       summary: Get all tags
       tags:
       - tags
-  /unfavorite:
-    delete:
-      description: Unfavorites a recipe for the authenticated user using its recipe
-        ID
-      parameters:
-      - description: Recipe ID
-        in: path
-        name: recipeId
-        required: true
-        type: integer
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/controller.SimpleMessageResponse'
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/controller.ErrorResponse'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/controller.ErrorResponse'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/controller.ErrorResponse'
-      summary: Remove a recipe from favorites
-      tags:
-      - favorites
   /user/favorites:
     get:
       description: Retrieve a paginated list of favorite recipes for the logged-in

--- a/model/models.go
+++ b/model/models.go
@@ -44,6 +44,7 @@ type User struct {
 	Salt                   string     `json:"salt"`
 	Password               string     `json:"password"`
 	Email                  string     `json:"email"`
+	Role                   string     `gorm:"deafault:user" json:"role"`
 	PasswordResetToken     string     `json:"-" gorm:"size:255"`
 	PasswordResetExpiresAt *time.Time `json:"-"`
 	Comments               []Comment  `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE" json:"comments"`

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -108,4 +108,48 @@ func AddRoutes(r *gin.Engine) {
 		// Generic image routes
 		protected.GET("/image/:entity/:entityId/:imageId", controller.GetImageHandler)
 	}
+
+	admin := r.Group("/admin")
+	admin.Use(middleware.AuthenticatJWT())
+	admin.Use(middleware.AdminOnly())
+	admin.Use(middleware.SetLanguage())
+	{
+		// Users routes
+		admin.GET("/users", controller.GetAllUsersHandler)
+		admin.GET("user/:id", controller.GetUserProfile)
+		admin.GET("/user/:id/recipes", controller.GetUserRecipesHandler)
+		admin.GET("/user/:id/favorites", controller.GetUserFavoritesHandler)
+		admin.GET("/user/:id/ratings", controller.GetUserRatingsHandler)
+
+		// Recipe routes
+		admin.GET("/recipe-list", controller.GetAllRecipesHandler)
+		admin.GET("/recipe/:id", controller.GetRecipeHandler)
+		admin.PUT("/recipe/:id", controller.PutRecipeUpdateHandler)
+		admin.DELETE("/user/:userID/recipe/:id", controller.DeleteRecipeHandler)
+
+		// Category routes
+		admin.GET("/categories", controller.GetAllCategoriesHandler)
+		admin.GET("category/:id", controller.GetCategoryHandler)
+		admin.POST("/category", controller.PostCategoryHandler)
+		admin.PUT("/category/:id", controller.PutCategoryHandler)
+		admin.DELETE("/category/:id", controller.DeleteCategoryHandler)
+
+		// Comments routes
+		admin.GET("/comments", controller.GetAllComments)
+		admin.DELETE("/user/:userID/comment/:id", controller.DeleteCommentHandler)
+
+		// Tags routes
+		admin.GET("/tags", controller.GetAllTagsHandler)
+		admin.POST("/tag", controller.PostTagHandler)
+		admin.PUT("/tag/:id", controller.PutTagHandler)
+		admin.DELETE("/tag/:id", controller.DeleteTagHandler)
+
+		// ratings routes
+		admin.GET("/ratings", controller.GetAllRatings)
+		admin.DELETE("/user/:userID/rating/:id", controller.DeleteRatingHandler)
+
+		// Favorites routes
+		admin.GET("/favorites", controller.GetAllFavorites)
+		admin.DELETE("/user/:userID/unfavorite/:id", controller.DeleteFavoriteHandler)
+	}
 }

--- a/token/token.go
+++ b/token/token.go
@@ -12,12 +12,13 @@ import (
 
 var secretKey = []byte("secret-key")
 
-func GenerateToken(userID uint, email string) (string, error) {
+func GenerateToken(userID uint, email string, role string) (string, error) {
 
 	claims := jwt.MapClaims{
 		"sub":   userID,
 		"email": email,
-		"exp":   time.Now().Add(time.Hour * 24).Unix(), // Token expires in 24 hours
+		"role":  role,
+		"exp":   time.Now().Add(time.Hour * 24).Unix(),
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
@@ -38,7 +39,6 @@ func VerifyToken(tokenString string) (jwt.MapClaims, error) {
 		return nil, err
 	}
 
-	// validate claims
 	if claims, ok := token.Claims.(jwt.MapClaims); ok && token.Valid {
 		exp, ok := claims["exp"].(float64)
 		if !ok {

--- a/utils/query.go
+++ b/utils/query.go
@@ -86,17 +86,18 @@ func ApplyRecipeSorting(query *gorm.DB, sortParam string) *gorm.DB {
 		return query.Order("recipes.created_at DESC")
 	}
 }
+
 func ApplyCommentSorting(query *gorm.DB, sortParam string) *gorm.DB {
 	switch strings.ToLower(sortParam) {
 	case "likes_desc":
-		return query.Order("likes DESC")
+		return query.Order("comments.likes DESC")
 	case "likes_asc":
-		return query.Order("likes ASC")
+		return query.Order("comments.likes ASC")
 	case "date_asc":
-		return query.Order("created_at ASC")
+		return query.Order("comments.created_at ASC")
 	case "date_desc":
-		return query.Order("created_at DESC")
+		return query.Order("comments.created_at DESC")
 	default:
-		return query.Order("created_at DESC") // default sorting
+		return query.Order("comments.created_at DESC") // default sorting
 	}
 }


### PR DESCRIPTION
Implement middleware and routes for admin users to manage the platform. Changes include:
- Separate admin routes for viewing, updating, and deleting users, recipes, comments, favorites, and ratings.
- Updated Swagger annotations to document both public and admin endpoints.
- Applied role-based access control middleware to restrict admin actions.
- Ensured existing user endpoints remain unaffected by admin privileges.